### PR TITLE
send correct test process header, closes #10 closes #9 closes #8 clos…

### DIFF
--- a/ENDPOINT_STATUS.md
+++ b/ENDPOINT_STATUS.md
@@ -1,19 +1,37 @@
 # Status
 
 Check here to see if the library is known to be working or not against each DiGA endpoint, 
-together with information on how many companies are using each endpoint, and issue tracking if th endpoint is not working:
+together with information on how many companies are using each endpoint, and issue tracking if the endpoint is not working:
 
-## Code validation
+- CODE TEST OK = test codes are working
+- CODE TEST NOT OK = test codes are not working
+- CODE OK = real code validation has been attemped and verified to work
+- CODE NOT VERIFIED = real code validation probably works, but it has not been tested on a real code yet
+- CODE NOT OK = real code validation does not work
+- BILLING TEST OK = test bill is working
+- BILLING TEST NOT OK = test bill is not working
+- BILLING OK = billing has been attempted and verified to work
+- BILLING NOT VERIFIED = billing probably works, but it has not been verified with a real bill yet
+- BILLING NOT OK = billing does not work
 
-- [x] diga.bitmarck-daten.de - 85 companies
-- [ ] diga.apimisc.de - 3 companies - #3
-- [ ] diga-api.tk.de/diga/api/public/rest - 1 company - #4
-- [ ] da-api.gkvi.de - 5 companies - #5
-- [ ] diga.kkh.de - 1 company - #6
-- [ ] arge.da-api.aok.de - 3 companies - #7
-- [ ] itscare.da-api.aok.de - 3 companies - #8
-- [ ] kubus-it.da-api.aok.de - 2 companies - #9
 
-## Billing
+## Endpoints
 
-- [ ] diga.bitmarck-daten.de
+- diga.bitmarck-daten.de - 85 companies - CODE TEST OK - CODE NOT VERIFIED - BILLING TEST NOT OK - BILLING NOT OK
+- diga-api.tk.de/diga/api/public/rest - 1 company - CODE TEST OK - CODE NOT VERIFIED
+- da-api.gkvi.de - 5 companies - CODE TEST OK - CODE NOT VERIFIED
+- diga.kkh.de - 1 company - CODE TEST OK - CODE NOT VERIFIED
+- itscare.da-api.aok.de - 3 companies - CODE TEST OK - CODE NOT VERIFIED
+- kubus-it.da-api.aok.de - 2 companies - CODE TEST OK - CODE NOT VERIFIED
+- arge.da-api.aok.de - 3 companies - CODE TEST NOT OK - CODE NOT OK
+- diga.apimisc.de - 3 companies - CODE TEST NOT OK - CODE NOT OK
+
+## Summary 
+
+Endpoints covering 97/103 insurance companies are working with test code validation requests. 
+
+However, since this library is not used in production yet, we can not verify if real requests work or not. 
+We will update this as we find out. If you are using this library in production and you find out that a request to
+one of the un-verified endpoints works, please either send us a message or add a pull request updating this file.
+If you find out it doesn't work, create an Issue!
+

--- a/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
@@ -115,6 +115,11 @@ public final class DigaApiClient {
                     .senderIK(senderIk)
                     .recipientIK(codeInformation.getInsuranceCompanyIKNumber())
                     .encryptedContent(encryptedXmlBody)
+                    .processCode(
+                            DigaUtils.isDigaTestCode(codeInformation.getFullDigaCode())
+                                    ? DigaProcessCode.CODE_VALIDATION_TEST
+                                    : DigaProcessCode.CODE_VALIDATION
+                    )
                     .build();
             var httpResponse = httpClient.post(httpApiRequest);
             var decryptResponseBodyAttempt = encryptionFactory.newDecryption()

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
@@ -96,7 +96,7 @@ public class DigaOkHttpClient implements DigaHttpClient {
                 .setType(MultipartBody.FORM)
                 .addFormDataPart("iksender", DigaUtils.ikNumberWithoutPrefix(digaApiHttpRequest.getSenderIK()))
                 .addFormDataPart("ikempfaenger", DigaUtils.ikNumberWithoutPrefix(digaApiHttpRequest.getRecipientIK()))
-                .addFormDataPart("verfahren", digaApiHttpRequest.getVerfahren())
+                .addFormDataPart("verfahren", digaApiHttpRequest.getProcessCode().getCode())
                 .addFormDataPart("nutzdaten", "anfrage.cms", RequestBody.create(digaApiHttpRequest.getEncryptedContent()))
                 .build();
         return new Request.Builder()

--- a/src/main/java/com/alextherapeutics/diga/model/DigaApiHttpRequest.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaApiHttpRequest.java
@@ -32,9 +32,8 @@ public class DigaApiHttpRequest {
     /**
      * The Process type.
      */
-    // TODO make enum and change name
-    @Builder.Default
-    private String verfahren = "EDFC0";
+    @NonNull
+    private DigaProcessCode processCode;
     /**
      * The full URL (including https etc) of the DiGA API endpoint to send this to.
      */

--- a/src/main/java/com/alextherapeutics/diga/model/DigaProcessCode.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaProcessCode.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021-2021 Alex Therapeutics AB and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.alextherapeutics.diga.model;
+
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Valid DiGA API process codes.
+ * These go in the "Verfahrenskennung" header so that the API endpoint understands which type of request it is
+ */
+public enum DigaProcessCode {
+    CODE_VALIDATION("EDFC0"),
+    CODE_VALIDATION_TEST("TDFC0"),
+    BILLING("EDRE0"),
+    BILLING_TEST("TDRE0");
+
+    @Getter
+    private String code;
+    DigaProcessCode(String code) {
+        this.code = code;
+    }
+    private static final Map<String, DigaProcessCode> BY_CODE = new HashMap<>();
+    static {
+        for (DigaProcessCode code : values()) {
+            BY_CODE.put(code.code, code);
+        }
+    }
+    public static DigaProcessCode fromCode(int code) {
+        return BY_CODE.get(code);
+    }
+}


### PR DESCRIPTION
# Pull Request

### Description
<!-- describe your pull request -->
It turns out most of the API errors was because I forgot to set the correct test header in test requests. Woops!

I will close the issues for those endponits since this means they are in the same state as the bitmarck endpoints - verified test codes are working, but we have not verified if "real" codes are working or not (since we are not live in production with this library yet).

Two endpoints still do not work for test codes, but we now seem to cover 97/103 insurance companies for code validation!

I have updated the ENDPOINT_STATUS file to reflect this and also encourage other users to update us on if the requests work in production too :)

### Closes
<!-- add references to issues you are closing here -->
closes #10 closes #9 closes #8 closes #6 closes #5 closes #4

