### PR TITLE
Enhancement/#14 return xml on exception

### DIFF
--- a/.github/workflows/github-publish.yml
+++ b/.github/workflows/github-publish.yml
@@ -1,12 +1,6 @@
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'What to set pom version to'
-        required: true
-#on:
-#  release:
-#    types: [ created ]
+  release:
+    types: [ created ]
 
 jobs:
   deploy:
@@ -22,8 +16,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-#      - run: mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${GITHUB_REF##*/}
-      - run: mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${{ github.event.inputs.version }}
+      - run: mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${GITHUB_REF##*/}
       - run: mvn -Prelease deploy
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,12 +1,6 @@
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: 'What to set pom version to'
-        required: true
-
-#  release:
-#    types: [ created ]
+  release:
+    types: [ created ]
 
 jobs:
   deploy:
@@ -27,8 +21,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-#      - run: mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${GITHUB_REF##*/}
-      - run: mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${{ github.event.inputs.version }}
+      - run: mvn org.codehaus.mojo:versions-maven-plugin:2.7:set -DnewVersion=${GITHUB_REF##*/}
       - run: mvn -Prelease,maven deploy
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,26 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
                         <version>1.6.8</version>
@@ -194,8 +214,7 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
-<!--                            <autoReleaseAfterClose>true</autoReleaseAfterClose>-->
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -251,26 +270,6 @@
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
@@ -91,7 +91,7 @@ public final class DigaApiClient {
      * @param digaCode - the full code (16 letters) as a String object.
      * @return a {@link DigaCodeValidationResponse} object containing information on the response from the API. This response may contain errors, in which case there are error messages in the response as well as the raw XML request that was sent which you can access for debugging purposes or to save failed requests for retrying later.
      * @throws DigaCodeValidationException if given an invalid DiGA code
-     * @throws DigaXmlWriterException if we fail to create the XML request body to send to the API
+     * @throws DigaXmlWriterException      if we fail to create the XML request body to send to the API
      */
     public DigaCodeValidationResponse validateDigaCode(String digaCode) throws DigaXmlWriterException, DigaCodeValidationException {
         if (DigaUtils.isDigaTestCode(digaCode)) {
@@ -116,7 +116,7 @@ public final class DigaApiClient {
      * You can check that the invoice request succeeded by checking if (response.hasError()) {}. If hasError is false,
      * the invoice was successful.
      * @throws DigaCodeValidationException if given an invalid DiGA code
-     * @throws DigaXmlWriterException if we fail to create the XML request body (the XRechnung invoice)
+     * @throws DigaXmlWriterException      if we fail to create the XML request body (the XRechnung invoice)
      */
     public DigaInvoiceResponse invoiceDiga(DigaInvoice invoice) throws DigaCodeValidationException, DigaXmlWriterException {
         var billingInformation = codeParser.parseCodeForBilling(invoice.getValidatedDigaCode());
@@ -268,6 +268,7 @@ public final class DigaApiClient {
             throw new DigaApiException(e);
         }
     }
+
     private DigaCodeValidationResponse buildCodeValidationResponseFromException(byte[] xmlRequest, Throwable error, DigaCodeInformation information) {
         var response = DigaCodeValidationResponse.builder()
                 .hasError(true)
@@ -279,6 +280,7 @@ public final class DigaApiClient {
         addReceiverDetailsToResponse(response, information);
         return response;
     }
+
     private DigaInvoiceResponse buildInvoiceResponseFromException(byte[] xmlRequest, Throwable error, DigaBillingInformation information) {
         var response = DigaInvoiceResponse.builder()
                 .hasError(true)

--- a/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaApiClient.java
@@ -30,6 +30,7 @@ import org.apache.commons.io.IOUtils;
 import javax.xml.bind.JAXBException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Main entry point to perform code validation and invoicing against the DiGA API.
@@ -88,9 +89,11 @@ public final class DigaApiClient {
      * Attempt to validate a patient's DiGA code against the API.
      *
      * @param digaCode - the full code (16 letters) as a String object.
-     * @return a {@link DigaCodeValidationResponse} object containing information on the response from the API.
+     * @return a {@link DigaCodeValidationResponse} object containing information on the response from the API. This response may contain errors, in which case there are error messages in the response as well as the raw XML request that was sent which you can access for debugging purposes or to save failed requests for retrying later.
+     * @throws DigaCodeValidationException if given an invalid DiGA code
+     * @throws DigaXmlWriterException if we fail to create the XML request body to send to the API
      */
-    public DigaCodeValidationResponse validateDigaCode(String digaCode) throws DigaApiException {
+    public DigaCodeValidationResponse validateDigaCode(String digaCode) throws DigaXmlWriterException, DigaCodeValidationException {
         if (DigaUtils.isDigaTestCode(digaCode)) {
             log.error("A test code was entered: {}", digaCode);
             throw new DigaCodeValidationException("A test code was entered");
@@ -105,16 +108,17 @@ public final class DigaApiClient {
      *
      * @param invoice - individual invoice details
      * @return An object containing details on the response to the invoice request as well as request details such as
-     * which insurance company was sent to, which endpoint, IK, etc.
+     * which insurance company was sent to, which endpoint, IK, etc. This response may contain errors, in which case there are error messages in the object.
      * <p>
      * The contents of the Invoice itself is located in DigaInvoiceResponse.getRawXmlRequestBody(), you can fetch
      * that and use it for accounting needs.
      * <p>
      * You can check that the invoice request succeeded by checking if (response.hasError()) {}. If hasError is false,
      * the invoice was successful.
-     * @throws DigaApiException
+     * @throws DigaCodeValidationException if given an invalid DiGA code
+     * @throws DigaXmlWriterException if we fail to create the XML request body (the XRechnung invoice)
      */
-    public DigaInvoiceResponse invoiceDiga(DigaInvoice invoice) throws DigaApiException {
+    public DigaInvoiceResponse invoiceDiga(DigaInvoice invoice) throws DigaCodeValidationException, DigaXmlWriterException {
         var billingInformation = codeParser.parseCodeForBilling(invoice.getValidatedDigaCode());
         return performDigaInvoicing(invoice, billingInformation, DigaProcessCode.BILLING);
     }
@@ -124,10 +128,10 @@ public final class DigaApiClient {
      *
      * @param testCode               - one of the specified test codes
      * @param insuranceCompanyPrefix - the prefix of the company to send the request to (according to the mapping file at https://kkv.gkv-diga.de/)
-     * @return
-     * @throws DigaApiException
+     * @return An object containing details on the response from the API, including errors of such occured.
+     * @throws DigaXmlWriterException if we fail to create the XML request body to send to the API
      */
-    public DigaCodeValidationResponse sendTestCodeValidationRequest(DigaApiTestCode testCode, String insuranceCompanyPrefix) throws DigaApiException {
+    public DigaCodeValidationResponse sendTestCodeValidationRequest(DigaApiTestCode testCode, String insuranceCompanyPrefix) throws DigaXmlWriterException {
         var healthInsuranceInformation = healthInsuranceDirectory.getInformation(insuranceCompanyPrefix);
         var testCodeInformation = DigaCodeInformation.builder()
                 .fullDigaCode(testCode.getCode())
@@ -147,8 +151,9 @@ public final class DigaApiClient {
      * @param invoice                - the invoice to send
      * @param insuranceCompanyPrefix - the prefix of the company to send it to, as listed in the insurance company mapping file
      * @return An object containing details on the response as well as the request details. See 'invoiceDiga' method.
+     * @throws DigaXmlWriterException if we fail to create the XML request body (the XRechnung invoice)
      */
-    public DigaInvoiceResponse sendTestInvoiceRequest(DigaInvoice invoice, String insuranceCompanyPrefix) throws DigaApiException {
+    public DigaInvoiceResponse sendTestInvoiceRequest(DigaInvoice invoice, String insuranceCompanyPrefix) throws DigaXmlWriterException {
         var healthInsuranceInformation = healthInsuranceDirectory.getInformation(insuranceCompanyPrefix);
         var billingInformation = DigaBillingInformation.builder()
                 .endpoint(healthInsuranceInformation.getEndpunktKommunikationsstelle())
@@ -162,13 +167,13 @@ public final class DigaApiClient {
         return performDigaInvoicing(invoice, billingInformation, DigaProcessCode.BILLING_TEST);
     }
 
-    private DigaCodeValidationResponse performCodeValidation(DigaCodeInformation codeInformation) throws DigaApiException {
+    private DigaCodeValidationResponse performCodeValidation(DigaCodeInformation codeInformation) throws DigaXmlWriterException {
+        var xmlRequest = xmlRequestWriter.createCodeValidationRequest(codeInformation);
+        var encryptRequestAttempt = encryptionFactory.newEncryption()
+                .encryptionTarget(xmlRequest)
+                .recipientAlias(DigaUtils.ikNumberWithPrefix(codeInformation.getInsuranceCompanyIKNumber()))
+                .build();
         try {
-            var xmlRequest = xmlRequestWriter.createCodeValidationRequest(codeInformation);
-            var encryptRequestAttempt = encryptionFactory.newEncryption()
-                    .encryptionTarget(xmlRequest)
-                    .recipientAlias(DigaUtils.ikNumberWithPrefix(codeInformation.getInsuranceCompanyIKNumber()))
-                    .build();
             var encryptedXmlBody = encryptRequestAttempt.encrypt().toByteArray();
             var httpApiRequest = DigaApiHttpRequest.builder()
                     .url(DigaUtils.buildPostDigaEndpoint(codeInformation.getEndpoint()))
@@ -187,24 +192,23 @@ public final class DigaApiClient {
                     .build();
             var response = xmlRequestReader.readCodeValidationResponse(new ByteArrayInputStream(decryptResponseBodyAttempt.decrypt().toByteArray()));
             response.setHttpStatusCode(httpResponse.getStatusCode());
-            response.setRawXmlRequestBody(IOUtils.toString(xmlRequest, "UTF-8"));
+            response.setRawXmlRequestBody(xmlRequest);
             response.setRawXmlRequestBodyEncrypted(encryptedXmlBody);
             addReceiverDetailsToResponse(response, codeInformation);
             return response;
-        } catch (IOException | JAXBException | DigaHttpClientException | SeconException e) {
-            // TODO fix catch all here, see issue #14
-            log.error("Failed to validate DiGA code", e);
-            throw new DigaApiException(e);
+        } catch (DigaHttpClientException | DigaEncryptionException | DigaDecryptionException | DigaXmlReaderException e) {
+            log.error("Failed to validate DiGA code {}", codeInformation.getFullDigaCode(), e);
+            return buildCodeValidationResponseFromException(xmlRequest, e, codeInformation);
         }
     }
 
-    private DigaInvoiceResponse performDigaInvoicing(DigaInvoice invoice, DigaBillingInformation billingInformation, DigaProcessCode processCode) throws DigaApiException {
+    private DigaInvoiceResponse performDigaInvoicing(DigaInvoice invoice, DigaBillingInformation billingInformation, DigaProcessCode processCode) throws DigaXmlWriterException {
+        var xmlInvoice = xmlRequestWriter.createBillingRequest(invoice, billingInformation);
+        var encryptionAttempt = encryptionFactory.newEncryption()
+                .encryptionTarget(xmlInvoice)
+                .recipientAlias(DigaUtils.ikNumberWithPrefix(billingInformation.getInsuranceCompanyIKNumber()))
+                .build();
         try {
-            var xmlInvoice = xmlRequestWriter.createBillingRequest(invoice, billingInformation);
-            var encryptionAttempt = encryptionFactory.newEncryption()
-                    .encryptionTarget(xmlInvoice)
-                    .recipientAlias(DigaUtils.ikNumberWithPrefix(billingInformation.getInsuranceCompanyIKNumber()))
-                    .build();
             var encryptedXmlInvoice = encryptionAttempt.encrypt().toByteArray();
             var httpApiRequest = DigaApiHttpRequest.builder()
                     .encryptedContent(encryptedXmlInvoice)
@@ -220,14 +224,13 @@ public final class DigaApiClient {
             var decrypted = decryptAttempt.decrypt().toByteArray();
             var response = xmlRequestReader.readBillingReport(new ByteArrayInputStream(decrypted));
             response.setHttpStatusCode(httpResponse.getStatusCode());
-            response.setRawXmlRequestBody(IOUtils.toString(xmlInvoice, "UTF-8"));
+            response.setRawXmlRequestBody(xmlInvoice);
             response.setRawXmlRequestBodyEncrypted(encryptedXmlInvoice);
             addReceiverDetailsToResponse(response, billingInformation);
             return response;
-        } catch (IOException | JAXBException | DigaHttpClientException | SeconException e) {
-            // TODO fix catch all here, see issue #14
-            log.error("Failed to invoice DiGA", e);
-            throw new DigaApiException(e);
+        } catch (DigaHttpClientException | DigaDecryptionException | DigaEncryptionException | DigaXmlReaderException e) {
+            log.error("Failed to invoice DiGA for invoice id {}, code {}", invoice.getInvoiceId(), invoice.getValidatedDigaCode(), e);
+            return buildInvoiceResponseFromException(xmlInvoice, e, billingInformation);
         }
     }
 
@@ -264,5 +267,27 @@ public final class DigaApiClient {
             log.error("DigA API client initialization failed", e);
             throw new DigaApiException(e);
         }
+    }
+    private DigaCodeValidationResponse buildCodeValidationResponseFromException(byte[] xmlRequest, Throwable error, DigaCodeInformation information) {
+        var response = DigaCodeValidationResponse.builder()
+                .hasError(true)
+                .errors(Collections.singletonList(
+                        new DigaApiExceptionError(error)
+                ))
+                .rawXmlRequestBody(xmlRequest)
+                .build();
+        addReceiverDetailsToResponse(response, information);
+        return response;
+    }
+    private DigaInvoiceResponse buildInvoiceResponseFromException(byte[] xmlRequest, Throwable error, DigaBillingInformation information) {
+        var response = DigaInvoiceResponse.builder()
+                .hasError(true)
+                .errors(Collections.singletonList(
+                        new DigaApiExceptionError(error)
+                ))
+                .rawXmlRequestBody(xmlRequest)
+                .build();
+        addReceiverDetailsToResponse(response, information);
+        return response;
     }
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaApiException.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaApiException.java
@@ -19,7 +19,7 @@
 package com.alextherapeutics.diga;
 
 /**
- * The DiGA API client failed to perform the specified task
+ * The DiGA API client failed to initialize
  */
 public class DigaApiException extends Exception {
     public DigaApiException(String msg) {

--- a/src/main/java/com/alextherapeutics/diga/DigaCodeValidationException.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaCodeValidationException.java
@@ -21,7 +21,7 @@ package com.alextherapeutics.diga;
 /**
  * The provided DiGA Code was not valid.
  */
-public class DigaCodeValidationException extends DigaApiException {
+public class DigaCodeValidationException extends Exception {
     public DigaCodeValidationException(String msg) {
         super(msg);
     }

--- a/src/main/java/com/alextherapeutics/diga/DigaDecryptionException.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaDecryptionException.java
@@ -16,15 +16,13 @@
  *
  */
 
-package com.alextherapeutics.diga.model;
-
-import lombok.Data;
-import lombok.experimental.SuperBuilder;
+package com.alextherapeutics.diga;
 
 /**
- * A response to an invoice request to the DiGA API (#RE0)
+ * Decrypting an encrypted XML body response failed
  */
-@SuperBuilder
-@Data
-public class DigaInvoiceResponse extends AbstractDigaApiResponse {
+public class DigaDecryptionException extends Exception {
+    public DigaDecryptionException(Throwable e) {
+        super("Diga decryption failed due to exception", e);
+    }
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaEncryptionException.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaEncryptionException.java
@@ -16,15 +16,14 @@
  *
  */
 
-package com.alextherapeutics.diga.model;
+package com.alextherapeutics.diga;
 
-import lombok.Data;
-import lombok.experimental.SuperBuilder;
 
 /**
- * A response to an invoice request to the DiGA API (#RE0)
+ * Encrypting an XML body request failed
  */
-@SuperBuilder
-@Data
-public class DigaInvoiceResponse extends AbstractDigaApiResponse {
+public class DigaEncryptionException extends Exception {
+    public DigaEncryptionException(Throwable e) {
+        super("Diga encryption failed due to exception", e);
+    }
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaHttpClient.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaHttpClient.java
@@ -30,7 +30,7 @@ public interface DigaHttpClient {
      *
      * @param request
      * @return A {@link DigaApiHttpResponse} containing response information including the encrpyted data body (if received)
-     * @throws DigaHttpClientException
+     * @throws DigaHttpClientException if the request failed
      */
     DigaApiHttpResponse post(DigaApiHttpRequest request) throws DigaHttpClientException;
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaHttpClientException.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaHttpClientException.java
@@ -22,7 +22,7 @@ package com.alextherapeutics.diga;
  * The DiGA HTTP client failed to perform the specified task
  */
 public class DigaHttpClientException extends Exception {
-    public DigaHttpClientException(String msg) {
-        super(msg);
+    public DigaHttpClientException(Throwable e) {
+        super("Diga Http Client error", e);
     }
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaXmlReaderException.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaXmlReaderException.java
@@ -16,15 +16,14 @@
  *
  */
 
-package com.alextherapeutics.diga.model;
-
-import lombok.Data;
-import lombok.experimental.SuperBuilder;
+package com.alextherapeutics.diga;
 
 /**
- * A response to an invoice request to the DiGA API (#RE0)
+ * Thrown when the library fails to read the XML response from the 'nutzdaten' data part of a DiGA API response
+ * Inspect the underlying exception for details
  */
-@SuperBuilder
-@Data
-public class DigaInvoiceResponse extends AbstractDigaApiResponse {
+public class DigaXmlReaderException extends Exception {
+    public DigaXmlReaderException(Throwable e) {
+        super("Exception thrown when trying to read XML request body: ", e);
+    }
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaXmlRequestReader.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaXmlRequestReader.java
@@ -21,8 +21,6 @@ package com.alextherapeutics.diga;
 import com.alextherapeutics.diga.model.DigaCodeValidationResponse;
 import com.alextherapeutics.diga.model.DigaInvoiceResponse;
 
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
 import java.io.InputStream;
 
 /**
@@ -34,18 +32,16 @@ public interface DigaXmlRequestReader {
      *
      * @param decryptedResponse
      * @return Relevant information in a new {@link DigaCodeValidationResponse} object. Note that the DigaApiResponse object contains fields which are not set by XML readers, like the HTTP status code.
-     * @throws JAXBException
-     * @throws IOException
+     * @throws DigaXmlReaderException when reading the request body failed
      */
-    DigaCodeValidationResponse readCodeValidationResponse(InputStream decryptedResponse) throws JAXBException, IOException;
+    DigaCodeValidationResponse readCodeValidationResponse(InputStream decryptedResponse) throws DigaXmlReaderException;
 
     /**
      * Read an inputstream with XML contents containing the validation report from a DiGA invoice and parse it.
      *
      * @param decryptedReport
      * @return Relevant information in a new {@link DigaInvoiceResponse} object.
-     * @throws JAXBException
-     * @throws IOException
+     * @throws DigaXmlReaderException when reading the request body failed
      */
-    DigaInvoiceResponse readBillingReport(InputStream decryptedReport) throws JAXBException, IOException;
+    DigaInvoiceResponse readBillingReport(InputStream decryptedReport) throws DigaXmlReaderException;
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaXmlRequestWriter.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaXmlRequestWriter.java
@@ -34,10 +34,9 @@ public interface DigaXmlRequestWriter {
      *
      * @param codeInformation - information required to create the request
      * @return A byte array containing a (non-encrypted) PruefungFreischaltcode - Anfrage XML request
-     * @throws JAXBException
-     * @throws IOException
+     * @throws DigaXmlWriterException - if the request body couldn't be created
      */
-    byte[] createCodeValidationRequest(DigaCodeInformation codeInformation) throws JAXBException, IOException;
+    byte[] createCodeValidationRequest(DigaCodeInformation codeInformation) throws DigaXmlWriterException;
 
     /**
      * Create a XML request body containing a DiGA invoice (an "XRechnung" invoice conforming to UN/CEFACT standard)
@@ -45,8 +44,7 @@ public interface DigaXmlRequestWriter {
      * @param invoice            - information required to create the invoice
      * @param billingInformation - information on the buyer
      * @return A byte array containing a (non-encrypted) XRechnung XML invoice
-     * @throws JAXBException
-     * @throws IOException
+     * @throws DigaXmlWriterException - if the request body couldn't be created
      */
-    byte[] createBillingRequest(DigaInvoice invoice, DigaBillingInformation billingInformation) throws JAXBException, IOException;
+    byte[] createBillingRequest(DigaInvoice invoice, DigaBillingInformation billingInformation) throws DigaXmlWriterException;
 }

--- a/src/main/java/com/alextherapeutics/diga/DigaXmlRequestWriter.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaXmlRequestWriter.java
@@ -22,9 +22,6 @@ import com.alextherapeutics.diga.model.DigaBillingInformation;
 import com.alextherapeutics.diga.model.DigaCodeInformation;
 import com.alextherapeutics.diga.model.DigaInvoice;
 
-import javax.xml.bind.JAXBException;
-import java.io.IOException;
-
 /**
  * Creates raw XML data bodies containing code validation requests or DiGA invoices.
  */

--- a/src/main/java/com/alextherapeutics/diga/DigaXmlWriterException.java
+++ b/src/main/java/com/alextherapeutics/diga/DigaXmlWriterException.java
@@ -16,15 +16,14 @@
  *
  */
 
-package com.alextherapeutics.diga.model;
-
-import lombok.Data;
-import lombok.experimental.SuperBuilder;
+package com.alextherapeutics.diga;
 
 /**
- * A response to an invoice request to the DiGA API (#RE0)
+ * Thrown when the library fails to write the XML request for an invoice or code validation request.
+ * This is a critical error which occurs early when creating a new request.
  */
-@SuperBuilder
-@Data
-public class DigaInvoiceResponse extends AbstractDigaApiResponse {
+public class DigaXmlWriterException extends Exception {
+    public DigaXmlWriterException(Throwable e) {
+        super("Exception thrown when trying to create XML request body: ", e);
+    }
 }

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaOkHttpClient.java
@@ -73,7 +73,7 @@ public class DigaOkHttpClient implements DigaHttpClient {
             return parseResponse(httpResponse);
         } catch (IOException e) {
             log.error("Http request failed", e);
-            throw new DigaHttpClientException(e.getMessage());
+            throw new DigaHttpClientException(e);
         }
     }
 
@@ -125,7 +125,7 @@ public class DigaOkHttpClient implements DigaHttpClient {
                     .build();
         } catch (IOException | CertificateException | NoSuchAlgorithmException | KeyStoreException e) {
             log.error("Failed to instantiate OkHttpClient", e);
-            throw new DigaHttpClientException(e.getMessage());
+            throw new DigaHttpClientException(e);
         }
     }
 

--- a/src/main/java/com/alextherapeutics/diga/model/AbstractDigaApiResponse.java
+++ b/src/main/java/com/alextherapeutics/diga/model/AbstractDigaApiResponse.java
@@ -21,6 +21,10 @@ package com.alextherapeutics.diga.model;
 import lombok.Builder;
 import lombok.Data;
 import lombok.experimental.SuperBuilder;
+import org.apache.commons.io.IOUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Common fields for all responses from the DiGA API
@@ -40,13 +44,19 @@ public abstract class AbstractDigaApiResponse {
     @Builder.Default
     private boolean hasError = false;
     /**
-     * The raw decrypted XML response body encoded as an UTF-8 string.
+     * Information on errors returned by the API endpoints or exceptions thrown when handling the data from the API.
+     * If there are no errors present, this is an empty list.
      */
-    private String rawXmlResponseBody;
+    @Builder.Default
+    private List<DigaApiResponseError> errors = new ArrayList<>();
     /**
-     * The raw XML request body pre-encryption encoded as an UTF-8 string.
+     * The raw decrypted XML response body. To read it, convert to a String with for example {@link IOUtils#toString()}
      */
-    private String rawXmlRequestBody;
+    private byte[] rawXmlResponseBody;
+    /**
+     * The raw XML request body pre-encryption. To read it, convert to a String with for example {@link IOUtils#toString()}
+     */
+    private byte[] rawXmlRequestBody;
     /**
      * The raw **encrypted** XML body.
      */

--- a/src/main/java/com/alextherapeutics/diga/model/DigaApiExceptionError.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaApiExceptionError.java
@@ -18,13 +18,16 @@
 
 package com.alextherapeutics.diga.model;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.experimental.SuperBuilder;
+import lombok.ToString;
 
 /**
- * A response to an invoice request to the DiGA API (#RE0)
+ * An error which occured by an exception being thrown inside the library.
  */
-@SuperBuilder
+@AllArgsConstructor
 @Data
-public class DigaInvoiceResponse extends AbstractDigaApiResponse {
+@ToString
+public class DigaApiExceptionError implements DigaApiResponseError {
+    private Throwable exception;
 }

--- a/src/main/java/com/alextherapeutics/diga/model/DigaApiResponseError.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaApiResponseError.java
@@ -28,12 +28,14 @@ public interface DigaApiResponseError {
      * Get information on this error as a String.
      * This method should be implemented so as to not lose any information contained in the error object itself, so
      * the returned string may be extensive.
+     *
      * @return - the error as a string
      */
     String toString();
 
     /**
      * Synonymous with {@link #toString()}
+     *
      * @return
      */
     default String getError() {

--- a/src/main/java/com/alextherapeutics/diga/model/DigaApiResponseError.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaApiResponseError.java
@@ -18,28 +18,25 @@
 
 package com.alextherapeutics.diga.model;
 
-import lombok.Builder;
-import lombok.Getter;
-import lombok.ToString;
-
 /**
- * An error received from sending a DiGA XML invoice.
+ * An error returned while communicating with the DiGA API
+ * This can both be an error returned from the API endpoints, or an error which occured within the library
+ * while interacting with the API endpoint - such as exceptions when decrypting data or sending the http request etc.
  */
-@Builder
-@Getter
-@ToString
-public class DigaInvoiceResponseError implements DigaApiResponseError {
+public interface DigaApiResponseError {
     /**
-     * The ID of the validation step that errored
+     * Get information on this error as a String.
+     * This method should be implemented so as to not lose any information contained in the error object itself, so
+     * the returned string may be extensive.
+     * @return - the error as a string
      */
-    private String validationStepId;
+    String toString();
+
     /**
-     * The messages received for the error in the report
+     * Synonymous with {@link #toString()}
+     * @return
      */
-    private String messages;
-    /**
-     * The "Resource" that was not valid. This will give information on which schema/schematron/xsl was used for
-     * validating this error.
-     */
-    private String resources;
+    default String getError() {
+        return toString();
+    }
 }

--- a/src/main/java/com/alextherapeutics/diga/model/DigaCodeValidationResponse.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaCodeValidationResponse.java
@@ -22,7 +22,6 @@ import lombok.Data;
 import lombok.experimental.SuperBuilder;
 
 import java.util.Date;
-import java.util.List;
 
 /**
  * Collects the information received from an API response for a code validation request.
@@ -39,14 +38,10 @@ public class DigaCodeValidationResponse extends AbstractDigaApiResponse {
     /**
      * The full DiGAVEid which was validated.
      * It consists of your DiGAID + 3 numbers. It is unclear what the last 3 digits mean so far, but you need to put this
-     * DiGAVEid in the invoice you send to get paid for this code validation, see {@link DigaInvoice#digavEid}.
+     * DiGAVEid in the invoice you send to get paid for this code validation, see {@link DigaInvoice#getDigavEid()}.
      */
     private String validatedDigaveid;
 
     // TODO figure out what this translation means ("tag der leistungserbringung" from "antwort")
     private Date dayOfServiceProvision;
-    /**
-     * Information on the errors contained in the XML response, if errors were present (otherwise empty list or null).
-     */
-    private List<DigaCodeValidationResponseError> errors;
 }

--- a/src/main/java/com/alextherapeutics/diga/model/DigaCodeValidationResponseError.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaCodeValidationResponseError.java
@@ -20,13 +20,15 @@ package com.alextherapeutics.diga.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.ToString;
 
 /**
  * Error information received from an XML response
  */
 @AllArgsConstructor
 @Data
-public class DigaCodeValidationResponseError {
+@ToString
+public class DigaCodeValidationResponseError implements DigaApiResponseError {
     /**
      * An API error code as described in the documentation at
      * https://www.gkv-datenaustausch.de/leistungserbringer/digitale_gesundheitsanwendungen/digitale_gesundheitsanwendungen.jsp

--- a/src/main/java/com/alextherapeutics/diga/model/DigaDecryption.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaDecryption.java
@@ -18,6 +18,7 @@
 
 package com.alextherapeutics.diga.model;
 
+import com.alextherapeutics.diga.DigaDecryptionException;
 import de.tk.opensource.secon.*;
 import lombok.Builder;
 import lombok.NonNull;
@@ -51,22 +52,26 @@ public class DigaDecryption {
      * @throws IOException
      * @throws SeconException
      */
-    public ByteArrayOutputStream decrypt() throws IOException, SeconException {
-        try (var outputStream = new ByteArrayOutputStream()) {
-            try (var inputStream = new ByteArrayInputStream(decryptionTarget)) {
-                SECON.copy(
-                        subscriber.decryptAndVerifyFrom(
-                                () -> inputStream,
-                                Verifier.NULL
-                        ),
-                        () -> outputStream
-                );
-                return outputStream;
-            } catch (CertificateNotFoundException e) {
-                // there seems to be something wrong in the key list from itsg which means some certificates have the wrong serial number on returning a response. in the future hopefully this is not a necessary catch
-                log.debug("Failed to validate sender certificate after (successfully) finishing decrypting the content.\n Since we wouldnt get this far without the server and us having the correct private and public keys for eachother, we pass the decrypted content as a success.");
-                return outputStream;
+    public ByteArrayOutputStream decrypt() throws DigaDecryptionException {
+        try {
+            try (var outputStream = new ByteArrayOutputStream()) {
+                try (var inputStream = new ByteArrayInputStream(decryptionTarget)) {
+                    SECON.copy(
+                            subscriber.decryptAndVerifyFrom(
+                                    () -> inputStream,
+                                    Verifier.NULL
+                            ),
+                            () -> outputStream
+                    );
+                    return outputStream;
+                } catch (CertificateNotFoundException e) {
+                    // there seems to be something wrong in the key list from itsg which means some certificates have the wrong serial number on returning a response. in the future hopefully this is not a necessary catch
+                    log.debug("Failed to validate sender certificate after (successfully) finishing decrypting the content.\n Since we wouldnt get this far without the server and us having the correct private and public keys for eachother, we pass the decrypted content as a success.");
+                    return outputStream;
+                }
             }
+        } catch (IOException | SeconException e) {
+            throw new DigaDecryptionException(e);
         }
     }
 }

--- a/src/main/java/com/alextherapeutics/diga/model/DigaEncryption.java
+++ b/src/main/java/com/alextherapeutics/diga/model/DigaEncryption.java
@@ -18,6 +18,7 @@
 
 package com.alextherapeutics.diga.model;
 
+import com.alextherapeutics.diga.DigaEncryptionException;
 import de.tk.opensource.secon.SECON;
 import de.tk.opensource.secon.SeconException;
 import de.tk.opensource.secon.Subscriber;
@@ -56,17 +57,21 @@ public class DigaEncryption {
      *
      * @return
      */
-    public ByteArrayOutputStream encrypt() throws IOException, SeconException {
-        try (var input = new ByteArrayInputStream(encryptionTarget)) {
-            try (var output = new ByteArrayOutputStream()) {
-                SECON.copy(
-                        () -> new ByteArrayInputStream(input.readAllBytes()),
-                        subscriber.signAndEncryptTo(
-                                () -> output, recipientAlias
-                        )
-                );
-                return output;
+    public ByteArrayOutputStream encrypt() throws DigaEncryptionException {
+        try {
+            try (var input = new ByteArrayInputStream(encryptionTarget)) {
+                try (var output = new ByteArrayOutputStream()) {
+                    SECON.copy(
+                            () -> new ByteArrayInputStream(input.readAllBytes()),
+                            subscriber.signAndEncryptTo(
+                                    () -> output, recipientAlias
+                            )
+                    );
+                    return output;
+                }
             }
+        } catch (IOException | SeconException e) {
+            throw new DigaEncryptionException(e);
         }
     }
 }

--- a/src/test/java/com/alextherapeutics/diga/DigaApiClientTest.java
+++ b/src/test/java/com/alextherapeutics/diga/DigaApiClientTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021-2021 Alex Therapeutics AB and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.alextherapeutics.diga;
+
+import com.alextherapeutics.diga.model.*;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.math.BigDecimal;
+
+class DigaApiClientTest {
+    private DigaApiClient client;
+    private DigaEncryptionFactory encryptionFactory;
+    private DigaHttpClient httpClient;
+    private DigaCodeParser codeParser;
+    private DigaHealthInsuranceDirectory healthInsuranceDirectory;
+    private DigaXmlRequestWriter xmlRequestWriter;
+    private DigaXmlRequestReader xmlRequestReader;
+    private DigaInformation digaInformation;
+
+    @BeforeEach
+    void setUp() {
+        digaInformation = DigaInformation.builder()
+                        .digaId("12345")
+                        .digaName("MyDiga")
+                        .manufacturingCompanyName("My Diga Company")
+                        .manufacturingCompanyIk("123456789")
+                        .netPricePerPrescription(new BigDecimal(100))
+                        .applicableVATpercent(new BigDecimal(19))
+                        .manufacturingCompanyVATRegistration("DE 123 456")
+                        .contactPersonForBilling(
+                                DigaInformation.ContactPersonForBilling.builder()
+                                        .fullName("Sven Svensson")
+                                        .phoneNumber("+46 70 123 45 67")
+                                        .emailAddress("diga@diga.de")
+                                        .build()
+                        )
+                        .companyTradeAddress(
+                                DigaInformation.CompanyTradeAddress.builder()
+                                        .adressLine("Test Street 1")
+                                        .postalCode("123 45")
+                                        .city("Stockholm")
+                                        .countryCode("SE")
+                                        .build()
+                        )
+                        .build();
+        encryptionFactory = Mockito.mock(DigaEncryptionFactory.class);
+        httpClient = Mockito.mock(DigaHttpClient.class);
+        codeParser = Mockito.mock(DigaCodeParser.class);
+        healthInsuranceDirectory = Mockito.mock(DigaHealthInsuranceDirectory.class);
+        xmlRequestWriter = Mockito.mock(DigaXmlRequestWriter.class);
+        xmlRequestReader = Mockito.mock(DigaXmlRequestReader.class);
+
+        client = DigaApiClient.builder()
+                .httpClient(httpClient)
+                .xmlRequestReader(xmlRequestReader)
+                .encryptionFactory(encryptionFactory)
+                .healthInsuranceDirectory(healthInsuranceDirectory)
+                .codeParser(codeParser)
+                .digaInformation(digaInformation)
+                .xmlRequestWriter(xmlRequestWriter)
+                .build();
+    }
+
+    @Test
+    void testValidateDigaCodeDoesntAcceptTestCodes() {
+        Assertions.assertThrows(
+                DigaCodeValidationException.class,
+                () -> client.validateDigaCode(DigaApiTestCode.ERROR_CODE_NOT_FOUND.getCode())
+        );
+    }
+    @Test
+    void testCodeParsingFailureRethrows() throws DigaCodeValidationException {
+        var code = "wrong";
+        Mockito.when(codeParser.parseCodeForValidation(code)).thenThrow(DigaCodeValidationException.class);
+        Assertions.assertThrows(
+                DigaCodeValidationException.class,
+                () -> client.validateDigaCode(code)
+        );
+    }
+    @Test
+    void testXmlWritingFailureRethrows() throws DigaXmlWriterException {
+        Mockito.when(xmlRequestWriter.createCodeValidationRequest(Mockito.any())).thenThrow(DigaXmlWriterException.class);
+        Assertions.assertThrows(
+                DigaXmlWriterException.class,
+                () -> client.validateDigaCode("hi")
+        );
+    }
+    @Test
+    void testExceptionAfterXmlWritingReturnsResponseCodeValidation() throws DigaEncryptionException, DigaXmlWriterException, DigaCodeValidationException {
+        var codeInfo = Mockito.mock(DigaCodeInformation.class);
+        Mockito.when(codeParser.parseCodeForValidation(Mockito.anyString())).thenReturn(codeInfo);
+        Mockito.when(codeInfo.getInsuranceCompanyIKNumber()).thenReturn("IK123456789");
+        var xmlRequest = new byte[]{5,6};
+        Mockito.when(xmlRequestWriter.createCodeValidationRequest(Mockito.any())).thenReturn(xmlRequest);
+        var encrBuild = Mockito.mock(DigaEncryption.DigaEncryptionBuilder.class, Mockito.RETURNS_SELF);
+        var encr = Mockito.mock(DigaEncryption.class);
+        Mockito.when(encryptionFactory.newEncryption()).thenReturn(encrBuild);
+        Mockito.when(encrBuild.build()).thenReturn(encr);
+        Mockito.when(encr.encrypt()).thenThrow(DigaEncryptionException.class);
+
+        var resp = client.validateDigaCode("my-code");
+        Assertions.assertTrue(resp.isHasError());
+        Assertions.assertTrue(resp.getErrors().size() > 0);
+        Assertions.assertNotNull(resp.getErrors().get(0).getError());
+        Assertions.assertArrayEquals(xmlRequest, resp.getRawXmlRequestBody());
+    }
+    @Test
+    void testExceptionAfterXmlWritingReturnsResponseBilling() throws DigaEncryptionException, DigaXmlWriterException, DigaCodeValidationException {
+        var invoice = DigaInvoice.builder().invoiceId("1").validatedDigaCode("code").digavEid("12345000").build();
+        var info = Mockito.mock(DigaBillingInformation.class);
+        Mockito.when(codeParser.parseCodeForBilling(Mockito.anyString())).thenReturn(info);
+        Mockito.when(info.getInsuranceCompanyIKNumber()).thenReturn("IK123456789");
+        var xmlRequest = new byte[]{5,6};
+        Mockito.when(xmlRequestWriter.createBillingRequest(invoice, info)).thenReturn(xmlRequest);
+        var encrBuild = Mockito.mock(DigaEncryption.DigaEncryptionBuilder.class, Mockito.RETURNS_SELF);
+        var encr = Mockito.mock(DigaEncryption.class);
+        Mockito.when(encryptionFactory.newEncryption()).thenReturn(encrBuild);
+        Mockito.when(encrBuild.build()).thenReturn(encr);
+        Mockito.when(encr.encrypt()).thenThrow(DigaEncryptionException.class);
+
+        var resp = client.invoiceDiga(invoice);
+        Assertions.assertTrue(resp.isHasError());
+        Assertions.assertTrue(resp.getErrors().size() > 0);
+        Assertions.assertNotNull(resp.getErrors().get(0).getError());
+        Assertions.assertArrayEquals(xmlRequest, resp.getRawXmlRequestBody());
+    }
+}

--- a/src/test/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestReaderTest.java
+++ b/src/test/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestReaderTest.java
@@ -18,6 +18,7 @@
 
 package com.alextherapeutics.diga.implementation;
 
+import com.alextherapeutics.diga.DigaXmlReaderException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -287,13 +288,13 @@ class DigaXmlJaxbRequestReaderTest {
     }
 
     @Test
-    void testReadBillingReportCompletesWithoutErrors() throws JAXBException, IOException {
+    void testReadBillingReportCompletesWithoutErrors() throws JAXBException, IOException, DigaXmlReaderException {
         var response = reader.readBillingReport(new ByteArrayInputStream(sampleBillingValidationReport.getBytes(StandardCharsets.UTF_8)));
         Assertions.assertNotNull(response);
     }
 
     @Test
-    void testReadCodeValidationResponseCompletesWithoutErrors() throws JAXBException, IOException {
+    void testReadCodeValidationResponseCompletesWithoutErrors() throws JAXBException, IOException, DigaXmlReaderException {
         var response = reader.readCodeValidationResponse(new ByteArrayInputStream(sampleCodeValidationAnswer.getBytes(StandardCharsets.UTF_8)));
         Assertions.assertNotNull(response);
     }

--- a/src/test/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriterTest.java
+++ b/src/test/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestWriterTest.java
@@ -18,6 +18,7 @@
 
 package com.alextherapeutics.diga.implementation;
 
+import com.alextherapeutics.diga.DigaXmlWriterException;
 import com.alextherapeutics.diga.model.DigaBillingInformation;
 import com.alextherapeutics.diga.model.DigaCodeInformation;
 import com.alextherapeutics.diga.model.DigaInformation;
@@ -65,7 +66,7 @@ class DigaXmlJaxbRequestWriterTest {
     }
 
     @Test
-    void testCreateCodeValidationRequestCompletesWithoutExceptions() throws JAXBException, IOException {
+    void testCreateCodeValidationRequestCompletesWithoutExceptions() throws JAXBException, IOException, DigaXmlWriterException {
         var res = writer.createCodeValidationRequest(
                 DigaCodeInformation.builder()
                         .fullDigaCode("dum")
@@ -79,7 +80,7 @@ class DigaXmlJaxbRequestWriterTest {
     }
 
     @Test
-    void testCreateBillingRequestCompletesWithoutExceptions() throws JAXBException, IOException {
+    void testCreateBillingRequestCompletesWithoutExceptions() throws JAXBException, IOException, DigaXmlWriterException {
         var res = writer.createBillingRequest(
                 DigaInvoice.builder()
                         .validatedDigaCode("dum")


### PR DESCRIPTION
# Pull Request

### Description
<!-- describe your pull request -->
- clean up exceptions to make it as simple as possible for users to find out what is happening
- IF xml request has been created when an exception occurs internally, return a response object with the error and with the xml request present. This enables users to store f.e a failed invoice or code validation request for use later, rather than it getting lost after the exception is thrown

### Closes
<!-- add references to issues you are closing here -->
closes #14 

