### PR TITLE
Fix invalid encoding

### DIFF
--- a/ENDPOINT_STATUS.md
+++ b/ENDPOINT_STATUS.md
@@ -18,7 +18,7 @@ together with information on how many companies are using each endpoint, and iss
 ## Endpoints
 
 - diga.bitmarck-daten.de - 85 companies - CODE TEST OK - CODE OK - BILLING TEST OK - BILLING OK
-- diga-api.tk.de/diga/api/public/rest - 1 company - CODE TEST OK - CODE NOT VERIFIED
+- diga-api.tk.de/diga/api/public/rest - 1 company - CODE TEST OK - CODE OK - BILLING TEST OK - BILLING OK
 - da-api.gkvi.de - 5 companies - CODE TEST OK - CODE OK - BILLING TEST OK - BILLING OK
 - diga.kkh.de - 1 company - CODE TEST OK - CODE NOT VERIFIED
 - itscare.da-api.aok.de - 3 companies - CODE TEST OK - CODE OK - BILLING TEST OK - BILLING NOT VERIFIED

--- a/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestReader.java
+++ b/src/main/java/com/alextherapeutics/diga/implementation/DigaXmlJaxbRequestReader.java
@@ -27,7 +27,6 @@ import com.alextherapeutics.diga.model.generatedxml.billingreport.ResourceType;
 import com.alextherapeutics.diga.model.generatedxml.billingreport.ValidationStepResultType;
 import com.alextherapeutics.diga.model.generatedxml.codevalidation.NachrichtentypStp;
 import com.alextherapeutics.diga.model.generatedxml.codevalidation.PruefungFreischaltcode;
-
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.Collections;
@@ -40,7 +39,6 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
-
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 
@@ -63,7 +61,8 @@ public class DigaXmlJaxbRequestReader implements DigaXmlRequestReader {
   public DigaInvoiceResponse readBillingReport(InputStream decryptedReport)
       throws DigaXmlReaderException {
     try {
-      XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader(decryptedReport);
+      XMLStreamReader xmlStream =
+          XMLInputFactory.newInstance().createXMLStreamReader(decryptedReport);
       var encoding = xmlStream.getEncoding();
       var charset = Charset.forName(encoding);
 


### PR DESCRIPTION
# Pull Request

### Description
It seems that some insurances (test case "Techniker Krankenkasse") despite specifying an encoding inside the billing report use invalid characters inside the response xml.
The "Techniker Krankenkasse" was made aware of this problem and they are going to check and fix the issue on their end eventually.
To circumvent the issue we can read the encoding specified inside the xml and use this to re-encode the data.

### Closes
 #49

