### PR TITLE
Fix double-consuming input stream in xml reader

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -1,6 +1,7 @@
 on:
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   test:
@@ -15,4 +16,6 @@ jobs:
       - name: Run Linting
         run: mvn spotless:check
       - name: Run Tests
-        run: mvn test
+        run: mvn clean test
+      - name: Run Xml Parser Tests
+        run: mvn clean test -P woodstox-parser

--- a/pom.xml
+++ b/pom.xml
@@ -316,6 +316,18 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <!-- for testing non-standard XML parser -->
+            <id>woodstox-parser</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.fasterxml.woodstox</groupId>
+                    <artifactId>woodstox-core</artifactId>
+                    <version>7.2.1</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
 </project>

--- a/src/main/java/se/maxk/diga/implementation/DigaXmlJaxbRequestReader.java
+++ b/src/main/java/se/maxk/diga/implementation/DigaXmlJaxbRequestReader.java
@@ -23,6 +23,7 @@ import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import java.io.*;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -61,14 +62,12 @@ public class DigaXmlJaxbRequestReader implements DigaXmlRequestReader {
   public DigaInvoiceResponse readBillingReport(InputStream decryptedReport)
       throws DigaXmlReaderException {
     try {
-      XMLStreamReader xmlStream =
-          XMLInputFactory.newInstance().createXMLStreamReader(decryptedReport);
-      var encoding = xmlStream.getEncoding();
-      var charset = Charset.forName(encoding);
+      var rawBytes = decryptedReport.readAllBytes();
+      var charset = getCharsetFromBytes(rawBytes);
 
       // xml is not always properly encoded despite the stated encoding in the xml
       // therefore we re-encode based on the specified encoding
-      var bytes = new String(decryptedReport.readAllBytes(), charset).getBytes();
+      var bytes = new String(rawBytes, charset).getBytes();
 
       var report = (Report) billingReportUnmarshaller.unmarshal(new ByteArrayInputStream(bytes));
       return DigaInvoiceResponse.builder()
@@ -219,5 +218,15 @@ public class DigaXmlJaxbRequestReader implements DigaXmlRequestReader {
               sb.append("\n");
             });
     return sb.toString();
+  }
+
+  private Charset getCharsetFromBytes(byte[] bytes) throws IOException, XMLStreamException {
+    var charset = StandardCharsets.UTF_8;
+    try (var in = new ByteArrayInputStream(bytes)) {
+      XMLStreamReader xmlStream = XMLInputFactory.newInstance().createXMLStreamReader(in);
+      var encoding = xmlStream.getEncoding();
+      charset = Charset.forName(encoding);
+    }
+    return charset;
   }
 }


### PR DESCRIPTION
# Pull Request

### Description
<!-- describe your pull request -->

- Fix bug where input stream was read twice in `DigaXmlJaxbRequestReader` leading to errors using non-vanilla XML parser

### Closes
<!-- add references to issues you are closing here -->
closes #237 
